### PR TITLE
Bump cardano-parts, add new tags for CloudF and Tofu resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /*.cert
 /cloudFormation/
-/.direnv
+/.direnv*
 /.envrc.local
 /.gcroots
 /*.log

--- a/Justfile
+++ b/Justfile
@@ -112,6 +112,7 @@ checkSshConfig := '''
       | where ($it.machine | str ends-with ".ipv4")
       | rename machine pubIpv4
       | update machine { $in | str replace ".ipv4" "" }
+      | update pubIpv4 { $in | if $in == "unavailable.ipv4" { null } else { $in } }
       | sort-by machine
     )
 
@@ -283,8 +284,17 @@ cardano-testnet isNg *ARGS:
 cf STACKNAME:
   #!/usr/bin/env nu
   mkdir cloudFormation
+  let secretName = (nix eval --raw '.#cardano-parts.cluster.infra.generic.costCenter')
+  let costCenter = (
+    just sops-decrypt-binary secrets/tf/cluster.tfvars
+    | lines
+    | where { |it| $it =~ $secretName }
+    | parse $"($secretName) = \"{secret}\""
+    | get 0.secret
+    | to text
+  )
   nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force 'cloudFormation/{{STACKNAME}}.json'
-  rain deploy --debug --termination-protection --yes ./cloudFormation/{{STACKNAME}}.json
+  rain deploy --debug --params costCenter=($costCenter) --termination-protection ./cloudFormation/{{STACKNAME}}.json
 
 # Prep dbsync for delegation analysis
 dbsync-prep ENV HOST ACCTS="501":
@@ -400,11 +410,11 @@ dedelegate-pools ENV *IDXS=null:
       --wallet-mnemonic <(just sops-decrypt-binary secrets/envs/{{ENV}}/utxo-keys/faucet.mnemonic) \
       --delegation-index "$i"
 
-    TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file tx-deleg-account-$i-restore.txsigned)
+    TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file tx-deleg-account-$i-restore.txsigned | jq -r .txhash)
     EXISTS="true"
 
     while [ "$EXISTS" = "true" ]; do
-      EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
+      EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists || true)
       if [ "$EXISTS" = "true" ]; then
         echo "Pool de-delegation index $i tx still exists in the mempool, sleeping 5s: $TXID"
       else

--- a/flake.lock
+++ b/flake.lock
@@ -102,6 +102,23 @@
         "type": "github"
       }
     },
+    "CHaP_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761315163,
+        "narHash": "sha256-h+JPIMflNAOpY3XhZNcS5sUAOyO06499uWATj2j6P5Q=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "131bcd51c4869b191e8c3afbb9f3fd326cd6e5e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
     "HTTP": {
       "flake": false,
       "locked": {
@@ -198,6 +215,22 @@
         "type": "github"
       }
     },
+    "HTTP_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "auth-keys-hub": {
       "inputs": {
         "flake-parts": [
@@ -276,28 +309,42 @@
     },
     "blockperf": {
       "inputs": {
-        "flake-parts": [
-          "cardano-parts",
-          "flake-parts"
-        ],
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs_15"
       },
       "locked": {
-        "lastModified": 1746509278,
-        "narHash": "sha256-/pcYYOKgD2+1Zl0jV+3S4h3GSp/3TSfokrqu0rDAijo=",
+        "lastModified": 1758832274,
+        "narHash": "sha256-na9CqAbZKVQLgxAwyxLOi2hlbQcRln3wgo5qTlBPefo=",
         "owner": "johnalotoski",
         "repo": "blockperf",
-        "rev": "cfc8155b9c14fedd569f879f2b3cf7ead91d47be",
+        "rev": "80c13b6b3cb6a3a17309851659909bd246e999c8",
         "type": "github"
       },
       "original": {
         "owner": "johnalotoski",
-        "ref": "preview-network",
+        "ref": "jl/fix-detail",
         "repo": "blockperf",
         "type": "github"
       }
     },
     "blst": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "blst_10": {
       "flake": false,
       "locked": {
         "lastModified": 1739372843,
@@ -552,6 +599,23 @@
         "type": "github"
       }
     },
+    "cabal-32_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -638,6 +702,23 @@
       }
     },
     "cabal-34_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34_7": {
       "flake": false,
       "locked": {
         "lastModified": 1645834128,
@@ -756,6 +837,23 @@
         "type": "github"
       }
     },
+    "cabal-36_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "call-flake": {
       "locked": {
         "lastModified": 1687380775,
@@ -773,11 +871,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1750254939,
-        "narHash": "sha256-P0N8TOddVyzHkIpDPdGsXbhR6W1vAhpOUvZPvyrrcNY=",
+        "lastModified": 1760451894,
+        "narHash": "sha256-GXy1zMjD73bmBpmK3f6V+rWCKQgfjQXzYUk9Dky+qso=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "ba03172728d491a2a1619755c885a3bcdbdfb43c",
+        "rev": "36068d0908d770da0498f9dcc254d17b17524e03",
         "type": "github"
       },
       "original": {
@@ -943,6 +1041,34 @@
         "type": "github"
       }
     },
+    "cardano-automation_7": {
+      "inputs": {
+        "flake-utils": "flake-utils_10",
+        "haskellNix": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750923974,
+        "narHash": "sha256-PXB1aro2KalRw6OZkcbICl6Ge7HB4yEl5O3epm9VZl8=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "64bf80a78102787790bac96075ef4109ff7de36e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "type": "github"
+      }
+    },
     "cardano-db-sync-schema": {
       "flake": false,
       "locked": {
@@ -985,6 +1111,22 @@
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "dbea349bfee8159bf443ce6fdeec4d3670ac3e70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "repo": "cardano-db-sync",
+        "type": "github"
+      }
+    },
+    "cardano-db-sync-service-ng": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1749798397,
+        "narHash": "sha256-3tzP/6KrFVoFAtguO/Yd7yRPXbldBSjWsrdO1sc9zA0=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-db-sync",
+        "rev": "da764296943a1de65a5085810bf70f55e6bda289",
         "type": "github"
       },
       "original": {
@@ -1156,6 +1298,41 @@
         "type": "github"
       }
     },
+    "cardano-node-10-6-0": {
+      "inputs": {
+        "CHaP": "CHaP_7",
+        "cardano-automation": "cardano-automation_7",
+        "customConfig": "customConfig_7",
+        "em": "em_7",
+        "empty-flake": "empty-flake_7",
+        "flake-compat": "flake-compat_14",
+        "hackageNix": "hackageNix_7",
+        "haskellNix": "haskellNix_7",
+        "incl": "incl_7",
+        "iohkNix": "iohkNix_7",
+        "nixpkgs": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "utils": "utils_8"
+      },
+      "locked": {
+        "lastModified": 1761827211,
+        "narHash": "sha256-butMOynyTKhLUrjocKuBnbAkDYhbnRKGEGdbTS773KQ=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "9a132bb72045e9462f0612e5df5af07c7206635a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "ana/10.6-final-integration-mix",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "cardano-node-cardano-diffusion": {
       "inputs": {
         "CHaP": "CHaP_3",
@@ -1228,33 +1405,33 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1746450573,
-        "narHash": "sha256-Szhph7YncIbQ+/QmqzSW61WLConBa8XIA6K/3A8mP00=",
-        "owner": "input-output-hk",
+        "lastModified": 1753292803,
+        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       }
     },
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1750182374,
-        "narHash": "sha256-fLNUecLWwZTvJuyekr53mb3fcC+tvCu6UBJuJ4vcYHI=",
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "7e045ab501e99130a57f363f0964bb4f241c6550",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.0",
+        "ref": "ana/10.6-final-integration-mix",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -1359,20 +1536,25 @@
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",
         "cardano-db-sync-service": "cardano-db-sync-service",
+        "cardano-db-sync-service-ng": "cardano-db-sync-service-ng",
         "cardano-metadata-service": "cardano-metadata-service",
+        "cardano-node-10-6-0": "cardano-node-10-6-0",
         "cardano-node-service": "cardano-node-service",
         "cardano-node-service-ng": "cardano-node-service-ng",
         "cardano-ogmios-service": "cardano-ogmios-service",
+        "cardano-submit-api-service": "cardano-submit-api-service",
+        "cardano-submit-api-service-ng": "cardano-submit-api-service-ng",
         "cardano-tracer-service": "cardano-tracer-service",
+        "cardano-tracer-service-ng": "cardano-tracer-service-ng",
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix_7",
         "nixpkgs": "nixpkgs_19",
-        "nixpkgs-unstable": "nixpkgs-unstable_7",
+        "nixpkgs-unstable": "nixpkgs-unstable_8",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
@@ -1381,16 +1563,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1750797952,
-        "narHash": "sha256-HbtXmIO1MUtdbeCaFbPst0jga1d8JUhhHmhAWbl4V2w=",
+        "lastModified": 1762552675,
+        "narHash": "sha256-gpeKzxd5wmxZl2v3LWR1vtUAlKXKCJna+pELy4fjWwI=",
         "owner": "input-output-hk",
         "repo": "cardano-parts",
-        "rev": "8684614a2bf7f250013579b1ee4ce7633aa1034c",
+        "rev": "39dcc23e3977984c3f01b4d8b9474cedec282def",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "v2025-06-24",
+        "ref": "next-2025-08-14",
         "repo": "cardano-parts",
         "type": "github"
       }
@@ -1491,19 +1673,86 @@
         "type": "github"
       }
     },
-    "cardano-tracer-service": {
+    "cardano-shell_7": {
       "flake": false,
       "locked": {
-        "lastModified": 1717175013,
-        "narHash": "sha256-b89kXIvJNRwz60fsRtZ7M1islKcVcl2+cSo7IkZu7ko=",
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "cardano-submit-api-service": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753292803,
+        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "ebb8be83e16b4e2a62e70bd8575013271e4b1886",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/tracer-service",
+        "repo": "cardano-node",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "type": "github"
+      }
+    },
+    "cardano-submit-api-service-ng": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "ana/10.6-final-integration-mix",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
+    "cardano-tracer-service": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1753292803,
+        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "type": "github"
+      }
+    },
+    "cardano-tracer-service-ng": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "ana/10.6-final-integration-mix",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -1527,8 +1776,8 @@
     },
     "colmena": {
       "inputs": {
-        "flake-compat": "flake-compat_14",
-        "flake-utils": "flake-utils_10",
+        "flake-compat": "flake-compat_16",
+        "flake-utils": "flake-utils_11",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "cardano-parts",
@@ -1626,6 +1875,21 @@
       }
     },
     "customConfig_6": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "customConfig_7": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -1831,6 +2095,22 @@
         "type": "github"
       }
     },
+    "em_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750940090,
+        "narHash": "sha256-DmDtgq8ipHCm2/Hq6e9xeJ2u8WLQFN1gXYSWM1bZNCU=",
+        "owner": "mgmeier",
+        "repo": "em",
+        "rev": "e3dde1952fcbe550055fb065590fdffd6f6f9710",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mgmeier",
+        "repo": "em",
+        "type": "github"
+      }
+    },
     "empty-flake": {
       "locked": {
         "lastModified": 1630400035,
@@ -1907,6 +2187,21 @@
       }
     },
     "empty-flake_6": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "empty-flake_7": {
       "locked": {
         "lastModified": 1630400035,
         "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
@@ -2009,6 +2304,40 @@
     "flake-compat_14": {
       "flake": false,
       "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_15": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_16": {
+      "flake": false,
+      "locked": {
         "lastModified": 1650374568,
         "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
@@ -2022,7 +2351,7 @@
         "type": "github"
       }
     },
-    "flake-compat_15": {
+    "flake-compat_17": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -2178,6 +2507,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1743550720,
         "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
@@ -2191,7 +2538,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "cardano-parts",
@@ -2229,6 +2576,21 @@
       }
     },
     "flake-utils_10": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_11": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -2449,6 +2811,23 @@
       }
     },
     "ghc-8.6.5-iohk_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk_7": {
       "flake": false,
       "locked": {
         "lastModified": 1600920045,
@@ -2741,6 +3120,39 @@
         "type": "github"
       }
     },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
     "hackageNix": {
       "flake": false,
       "locked": {
@@ -2838,6 +3250,22 @@
       "original": {
         "owner": "input-output-hk",
         "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761265459,
+        "narHash": "sha256-7tsC/ZcNBJR1pXWdKsRoh/qlVDhCxb1Ukr7PVd2zieE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "eb8e4d02528b4973cd09450bb62cf34997777226",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
         "repo": "hackage.nix",
         "type": "github"
       }
@@ -3184,6 +3612,65 @@
         "type": "github"
       }
     },
+    "haskellNix_7": {
+      "inputs": {
+        "HTTP": "HTTP_7",
+        "cabal-32": "cabal-32_7",
+        "cabal-34": "cabal-34_7",
+        "cabal-36": "cabal-36_7",
+        "cardano-shell": "cardano-shell_7",
+        "flake-compat": "flake-compat_15",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_7",
+        "hackage": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10_7",
+        "hls-2.0": "hls-2.0_7",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.2": "hls-2.2_7",
+        "hls-2.3": "hls-2.3_7",
+        "hls-2.4": "hls-2.4_7",
+        "hls-2.5": "hls-2.5_7",
+        "hls-2.6": "hls-2.6_7",
+        "hls-2.7": "hls-2.7_7",
+        "hls-2.8": "hls-2.8_7",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls_7",
+        "iserv-proxy": "iserv-proxy_7",
+        "nixpkgs": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305_7",
+        "nixpkgs-2311": "nixpkgs-2311_7",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-unstable": "nixpkgs-unstable_7",
+        "old-ghc-nix": "old-ghc-nix_7",
+        "stackage": "stackage_7"
+      },
+      "locked": {
+        "lastModified": 1755663895,
+        "narHash": "sha256-76Ns29GQsO5S5gPRcic+vagcJicOSvhA+oKQ9r9kjFE=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "71fcc9f531993aada52173fceb4ff4ce2148207d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
     "haumea": {
       "inputs": {
         "nixpkgs": [
@@ -3204,6 +3691,22 @@
         "owner": "nix-community",
         "ref": "v0.2.2",
         "repo": "haumea",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
         "type": "github"
       }
     },
@@ -3293,6 +3796,23 @@
       }
     },
     "hls-1.10_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10_7": {
       "flake": false,
       "locked": {
         "lastModified": 1680000865,
@@ -3411,6 +3931,57 @@
         "type": "github"
       }
     },
+    "hls-2.0_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.2": {
       "flake": false,
       "locked": {
@@ -3497,6 +4068,23 @@
       }
     },
     "hls-2.2_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2_7": {
       "flake": false,
       "locked": {
         "lastModified": 1693064058,
@@ -3615,6 +4203,23 @@
         "type": "github"
       }
     },
+    "hls-2.3_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.4": {
       "flake": false,
       "locked": {
@@ -3701,6 +4306,23 @@
       }
     },
     "hls-2.4_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4_7": {
       "flake": false,
       "locked": {
         "lastModified": 1699862708,
@@ -3819,6 +4441,23 @@
         "type": "github"
       }
     },
+    "hls-2.5_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.6": {
       "flake": false,
       "locked": {
@@ -3905,6 +4544,23 @@
       }
     },
     "hls-2.6_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6_7": {
       "flake": false,
       "locked": {
         "lastModified": 1705325287,
@@ -4023,6 +4679,23 @@
         "type": "github"
       }
     },
+    "hls-2.7_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hls-2.8": {
       "flake": false,
       "locked": {
@@ -4125,6 +4798,40 @@
         "type": "github"
       }
     },
+    "hls-2.8_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
     "hpc-coveralls": {
       "flake": false,
       "locked": {
@@ -4206,6 +4913,22 @@
       }
     },
     "hpc-coveralls_6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls_7": {
       "flake": false,
       "locked": {
         "lastModified": 1607498076,
@@ -4477,6 +5200,24 @@
         "type": "github"
       }
     },
+    "incl_7": {
+      "inputs": {
+        "nixlib": "nixlib_6"
+      },
+      "locked": {
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
+        "type": "github"
+      }
+    },
     "inclusive": {
       "inputs": {
         "stdlib": "stdlib"
@@ -4522,17 +5263,17 @@
     },
     "iohk-nix": {
       "inputs": {
-        "blst": "blst_7",
+        "blst": "blst_8",
         "nixpkgs": "nixpkgs_16",
-        "secp256k1": "secp256k1_7",
-        "sodium": "sodium_7"
+        "secp256k1": "secp256k1_8",
+        "sodium": "sodium_8"
       },
       "locked": {
-        "lastModified": 1747796208,
-        "narHash": "sha256-ZUBNrv+lO0CWhnN0R0ZiG/eIB+W5pnyAGsxf/lozECo=",
+        "lastModified": 1751421193,
+        "narHash": "sha256-rklXDo12dfukaSqcEyiYbze3ffRtTl2/WAAQCWfkGiw=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "281f635b01f8fe843baefe010a694f67041c0848",
+        "rev": "64ca6f4c0c6db283e2ec457c775bce75173fb319",
         "type": "github"
       },
       "original": {
@@ -4543,10 +5284,10 @@
     },
     "iohk-nix-9-2-1": {
       "inputs": {
-        "blst": "blst_9",
+        "blst": "blst_10",
         "nixpkgs": "nixpkgs_20",
-        "secp256k1": "secp256k1_9",
-        "sodium": "sodium_9"
+        "secp256k1": "secp256k1_10",
+        "sodium": "sodium_10"
       },
       "locked": {
         "lastModified": 1747798193,
@@ -4565,21 +5306,22 @@
     },
     "iohk-nix-ng": {
       "inputs": {
-        "blst": "blst_8",
+        "blst": "blst_9",
         "nixpkgs": "nixpkgs_17",
-        "secp256k1": "secp256k1_8",
-        "sodium": "sodium_8"
+        "secp256k1": "secp256k1_9",
+        "sodium": "sodium_9"
       },
       "locked": {
-        "lastModified": 1750025513,
-        "narHash": "sha256-WUNoYIZvU9moc5ccwJcF22r+bUJXO5dWoRyLPs8bJic=",
+        "lastModified": 1761066415,
+        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f63aa2a49720526900fb5943db4123b5b8dcc534",
+        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "jl/10.6.0-pre-updates",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -4728,6 +5470,32 @@
         "type": "github"
       }
     },
+    "iohkNix_7": {
+      "inputs": {
+        "blst": "blst_7",
+        "nixpkgs": [
+          "cardano-parts",
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1_7",
+        "sodium": "sodium_7"
+      },
+      "locked": {
+        "lastModified": 1761066415,
+        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "jl/10.6.0-pre-updates",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
     "iserv-proxy": {
       "flake": false,
       "locked": {
@@ -4821,6 +5589,23 @@
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
         "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "iserv-proxy_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
         "type": "github"
       },
       "original": {
@@ -5189,19 +5974,19 @@
     },
     "nix_7": {
       "inputs": {
-        "flake-compat": "flake-compat_15",
-        "flake-parts": "flake-parts_2",
+        "flake-compat": "flake-compat_17",
+        "flake-parts": "flake-parts_3",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_18",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression_7"
       },
       "locked": {
-        "lastModified": 1748154947,
-        "narHash": "sha256-rCpANMHFIlafta6J/G0ILRd+WNSnzv/lzi40Y8f1AR8=",
+        "lastModified": 1751027644,
+        "narHash": "sha256-f3ar0uez/+tc+PFtOTyjo7Vfa2xsLxl6K3vZt2Bs4so=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "d761dad79c79af17aa476a29749bd9d69747548f",
+        "rev": "8f6c5d088ad49df471168b769ae44f4ea0b915f3",
         "type": "github"
       },
       "original": {
@@ -5310,6 +6095,21 @@
       }
     },
     "nixlib_5": {
+      "locked": {
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixlib_6": {
       "locked": {
         "lastModified": 1667696192,
         "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
@@ -5930,6 +6730,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-2305_7": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-2311": {
       "locked": {
         "lastModified": 1701386440,
@@ -6026,7 +6842,89 @@
         "type": "github"
       }
     },
+    "nixpkgs-2311_7": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1743296961,
         "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
@@ -6251,6 +7149,22 @@
     },
     "nixpkgs-unstable_7": {
       "locked": {
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_8": {
+      "locked": {
         "lastModified": 1748248602,
         "narHash": "sha256-LanRAm0IRpL36KpCKSknEwkBFvTLc9mDHKeAmfTrHwg=",
         "owner": "nixos",
@@ -6361,32 +7275,32 @@
     },
     "nixpkgs_16": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_17": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-22.11",
+        "ref": "release-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -6679,6 +7593,23 @@
         "type": "github"
       }
     },
+    "old-ghc-nix_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "opentofu-registry": {
       "flake": false,
       "locked": {
@@ -6798,6 +7729,23 @@
       }
     },
     "secp256k1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_10": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -6966,6 +7914,23 @@
       }
     },
     "sodium": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
+    "sodium_10": {
       "flake": false,
       "locked": {
         "lastModified": 1675156279,
@@ -7251,6 +8216,22 @@
         "type": "github"
       }
     },
+    "stackage_7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
     "std": {
       "inputs": {
         "blank": "blank",
@@ -7472,6 +8453,21 @@
         "type": "github"
       }
     },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "terranix": {
       "inputs": {
         "flake-parts": [
@@ -7482,7 +8478,7 @@
           "cardano-parts",
           "nixpkgs"
         ],
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1747386897,
@@ -7652,6 +8648,24 @@
     "utils_7": {
       "inputs": {
         "systems": "systems_6"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "utils_8": {
+      "inputs": {
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,8 @@
     flake-parts.follows = "cardano-parts/flake-parts";
 
     # Using cardano-parts release v2025-06-24, we get SSH over SSM migration completed.
-    # Currently `cardano-parts` gives us access to cardano-node `10.4.1` and `10.5.0`.
-    cardano-parts.url = "github:input-output-hk/cardano-parts/v2025-06-24";
+    # Currently `cardano-parts` gives us access to cardano-node `10.5.1`.
+    cardano-parts.url = "github:input-output-hk/cardano-parts/next-2025-08-14";
 
     # Local pins for additional customization:
     cardano-node-tx-submission.url = "github:IntersectMBO/cardano-node/coot/tx-submission-10.5";

--- a/flake/cloudFormation/terraformState.nix
+++ b/flake/cloudFormation/terraformState.nix
@@ -12,23 +12,45 @@ with lib; {
           Key = n;
           Value = v;
         }) {
-          inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
-          environment = "generic";
+          inherit
+            (config.flake.cardano-parts.cluster.infra.generic)
+            environment
+            function
+            organization
+            owner
+            project
+            repo
+            tribe
+            ;
         })
       ++ [
         {
           Key = "Name";
           Value = name;
         }
+        {
+          Key = "costCenter";
+          Value = {
+            Ref = "costCenter";
+          };
+        }
       ];
   in {
     AWSTemplateFormatVersion = "2010-09-09";
     Description = "Terraform state handling";
 
+    # The costCenter parameter will be passed to the configuration via a secrets file.
+    # For details, see the just recipe: cf
+    Parameters = {
+      costCenter = {
+        Type = "String";
+        Description = "The costCenter tag";
+      };
+    };
+
     # Resources here will be created in the AWS_REGION and AWS_PROFILE from your
     # environment variables.
     # Execute this using: `just cf terraformState`
-
     Resources = {
       kmsKey = {
         Type = "AWS::KMS::Key";

--- a/flake/cluster.nix
+++ b/flake/cluster.nix
@@ -56,6 +56,13 @@
       function = "cardano-parts";
       repo = "https://github.com/input-output-hk/ouroboros-network-ops";
 
+      owner = "ioe";
+      environment = "mainnetNonProd";
+      project = "ouroboros-network-ops";
+
+      # This is the tf var secrets name located in secrets/tf/cluster.tfvars
+      costCenter = "tag_costCenter";
+
       # By default abort and warn if the ip-module is missing:
       abortOnMissingIpModule = true;
       warnOnMissingIpModule = true;

--- a/flake/colmena.nix
+++ b/flake/colmena.nix
@@ -7,8 +7,6 @@
 }: let
   inherit (config.flake) nixosModules nixosConfigurations;
   # inherit (config.flake.cardano-parts.cluster.infra.aws) domain;
-
-  cfgGeneric = config.flake.cardano-parts.cluster.infra.generic;
 in
   with builtins;
   with lib; {
@@ -59,7 +57,8 @@ in
 
         # Since all machines are assigned a group, this is a good place to include default aws instance tags
         aws.instance.tags = {
-          inherit (cfgGeneric) organization tribe function repo;
+          # This group environment name will override the
+          # flake.cluster.infra.generic environment name for aws instances.
           environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
           group = name;
         };
@@ -87,10 +86,16 @@ in
         imports = [
           # Base cardano-node service
           config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-tracer-service
 
           # Config for cardano-node group deployments
           inputs.cardano-parts.nixosModules.profile-cardano-node-group
           inputs.cardano-parts.nixosModules.profile-cardano-custom-metrics
+
+          # Keep legacy tracing for now
+          {
+            services.cardano-node.useLegacyTracing = true;
+          }
         ];
       };
 

--- a/flake/opentofu/cluster.nix
+++ b/flake/opentofu/cluster.nix
@@ -138,6 +138,28 @@ with lib; let
   groupMultivalueDnsAttrs = mkMultivalueDnsAttrs "groupRelayMultivalueDns" groupMultivalueDnsList;
 
   mkCustomRoute53Records = import ./cluster/route53.nix-import;
+
+  sensitiveString = {
+    type = "string";
+    sensitive = true;
+    nullable = false;
+  };
+
+  defaultTags = {
+    inherit
+      (infra.generic)
+      environment
+      function
+      organization
+      owner
+      project
+      repo
+      tribe
+      ;
+
+    # costCenter is saved as a secret
+    costCenter = "\${var.${infra.generic.costCenter}}";
+  };
 in {
   flake.opentofu.cluster = inputs.cardano-parts.inputs.terranix.lib.terranixConfiguration {
     inherit system;
@@ -161,13 +183,19 @@ in {
           };
         };
 
+        variable = {
+          # costCenter tag should remain secret in public repos
+          "${infra.generic.costCenter}" = sensitiveString;
+        };
+
         provider.aws = forEach (attrNames cluster.regions) (region: {
           inherit region;
           alias = underscore region;
-          default_tags.tags = {
-            inherit (infra.generic) organization tribe function repo;
-            environment = "generic";
-          };
+
+          # Default tagging is inconsistent across aws resources, but including
+          # it may help tag some resources that might have otherwise been
+          # missed.
+          default_tags.tags = defaultTags;
         });
 
         # Common parameters:
@@ -324,6 +352,8 @@ in {
                         gateway_id = "\${data.aws_internet_gateway.${region}.id}";
                       }
                     ];
+
+                  tags = defaultTags;
                 };
               }
           );
@@ -346,6 +376,7 @@ in {
                   + " cidrsubnet(${ipv6CidrBlock}, ${toString ipv6SubnetCidrBits} - parseint(tolist(regex(\"/([0-9]+)$\", ${ipv6CidrBlock}))[0], 10), each.key)}";
 
                 availability_zone = "\${each.value.availability_zone}";
+                tags = defaultTags;
               };
             });
 
@@ -358,6 +389,7 @@ in {
                 ${region} = {
                   provider = awsProviderFor region;
                   assign_generated_ipv6_cidr_block = true;
+                  tags = defaultTags;
                 };
               }
           );
@@ -378,6 +410,10 @@ in {
                 vpc_security_group_ids = [
                   "\${aws_security_group.common_${underscore region}[0].id}"
                 ];
+
+                # Provider level `default_tags` are automatically inherited at
+                # the instance level.  Instance specific tags defined in
+                # flake/colmena.nix are merged.
                 tags = {Name = name;} // node.aws.instance.tags or {};
 
                 root_block_device = {
@@ -386,14 +422,9 @@ in {
                   iops = node.aws.instance.root_block_device.iops or 3000;
                   throughput = node.aws.instance.root_block_device.throughput or 125;
                   delete_on_termination = true;
-                  tags =
-                    # Root block device tags aren't applied like the other
-                    # resources since terraform-aws-provider v5.39.0.
-                    #
-                    # We need to strip the following tag attrs or tofu
-                    # constantly tries to re-apply them.
-                    {Name = name;}
-                    // removeAttrs (node.aws.instance.tags or {}) ["organization" "tribe" "function" "repo"];
+
+                  # Default tags are not inherited to the volume level automatically.
+                  tags = defaultTags // {Name = name;} // node.aws.instance.tags or {};
                 };
 
                 metadata_options = {
@@ -433,6 +464,7 @@ in {
           aws_iam_instance_profile.ec2_profile = {
             name = "ec2Profile";
             role = "\${aws_iam_role.ec2_role.name}";
+            tags = defaultTags;
           };
 
           aws_iam_role.ec2_role = {
@@ -447,6 +479,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           aws_iam_role_policy_attachment = let
@@ -495,6 +529,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           tls_private_key.bootstrap.algorithm = "ED25519";
@@ -508,6 +544,7 @@ in {
               provider = awsProviderFor region;
               key_name = "bootstrap";
               public_key = "\${tls_private_key.bootstrap.public_key_openssh}";
+              tags = defaultTags;
             };
           });
 
@@ -515,6 +552,8 @@ in {
             inherit (node.aws.instance) count;
             provider = awsProviderFor node.aws.region;
             instance = "\${aws_instance.${name}[0].id}";
+
+            # Provider level `default_tags` are automatically inherited.
             tags = {Name = name;} // node.aws.instance.tags or {};
           });
 
@@ -592,6 +631,8 @@ in {
                     protocol = "-1";
                   })
                 ];
+
+                tags = defaultTags;
               };
             });
 

--- a/scripts/bash-fns.sh
+++ b/scripts/bash-fns.sh
@@ -2,27 +2,20 @@
 #
 # Various bash helper fns which aren't used enough to move to just recipes.
 
-# This can be used to simplify ssh sessions, rsync, ex:
-#   ssh -o "$(ssm-proxy-cmd "$REGION")" "$INSTANCE_ID"
-ssm-proxy-cmd() {
-  echo "ProxyCommand=sh -c 'aws --region $1 ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p'"
-}
-
-
 # A handy transaction submission function with mempool monitoring.
 # CARDANO_NODE_{NETWORK_ID,SOCKET_PATH}, TESTNET_MAGIC should already be exported.
 submit() (
   set -euo pipefail
   TX_SIGNED="$1"
 
-  TXID=$(cardano-cli latest transaction txid --tx-file "$TX_SIGNED")
+  TXID=$(cardano-cli latest transaction txid --tx-file "$TX_SIGNED" | jq -re .txhash)
 
   echo "Submitting $TX_SIGNED with txid $TXID..."
   cardano-cli latest transaction submit --tx-file "$TX_SIGNED"
 
   EXISTS="true"
   while [ "$EXISTS" = "true" ]; do
-    EXISTS=$(cardano-cli latest query tx-mempool tx-exists "$TXID" | jq -r .exists)
+    EXISTS=$(cardano-cli latest query tx-mempool tx-exists "$TXID" | jq -re .exists || true)
     if [ "$EXISTS" = "true" ]; then
       echo "The transaction still exists in the mempool, sleeping 5s: $TXID"
     else
@@ -73,4 +66,163 @@ foreach-pair() (
 
     eval "$cmd" || true
   done
+)
+
+return-utxo() (
+  set -euo pipefail
+
+  [ -n "${DEBUG:-}" ] && set -x
+  SIGNING_TX_ARGS=()
+
+  if [ "$#" -ne 4 ] && [ "$#" -ne 5 ]; then
+    # shellcheck disable=SC2016
+    echo "$0"' $ENV $SEND_ADDR $UTXO $PAYMENT_SKEY [$STAKE_SKEY]'
+    echo
+    echo "  ENV          -- The environment to be used"
+    echo "  SEND_ADDR    -- The send to address"
+    echo "  UTXO         -- The UTXO including index in \$UTXO#IDX format"
+    echo "  PAYMENT_SKEY -- The path to the payment secret key"
+    echo "  [STAKE_SKEY] -- The path to the stake secret key [Optional]"
+    exit 1
+  else
+    # Read file contents rather than saving the path in case it is a streamed
+    # file input redirection from a decryption output.
+    ENV="$1"
+    SEND_ADDR="$2"
+    UTXO="$3"
+    PAYMENT_SKEY=$(< "$4")
+    if [ "$#" -eq 5 ]; then
+      STAKE_SKEY=$(< "$5")
+    fi
+  fi
+
+  just set-default-cardano-env "$ENV"
+  echo
+
+  PROMPT() {
+    echo
+    read -p "Does this look correct [yY]? " -n 1 -r
+    echo
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "Aborting the fund transfer."
+      exit 1
+    fi
+    echo
+  }
+
+  TS=$(date -u +%y-%m-%d_%H-%M-%S)
+  BASENAME="tx-fund-transfer-$ENV-$TS"
+
+  PAYMENT_VKEY=$(cardano-cli latest key verification-key --signing-key-file <(echo -n "$PAYMENT_SKEY") --verification-key-file /dev/stdout)
+
+  if [ "$#" -eq 5 ]; then
+    STAKE_VKEY=$(cardano-cli latest key verification-key --signing-key-file <(echo -n "$STAKE_SKEY") --verification-key-file /dev/stdout)
+
+    SIGNING_TX_ARGS+=(
+      "--signing-key-file" "<(echo -n \"\$STAKE_SKEY\")"
+    )
+  fi
+
+  SOURCE_ADDR=$(
+    if [ "$#" -eq 4 ]; then
+      cardano-cli latest address build \
+        --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") 2> /dev/null
+    else
+      cardano-cli latest address build \
+        --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") \
+        --stake-verification-key-file <(echo -n "$STAKE_VKEY") 2> /dev/null \
+      || { \
+        STAKE_VKEY_FROM_EXT=$(cardano-cli latest key non-extended-key --extended-verification-key-file <(echo -n "$STAKE_VKEY") --verification-key-file /dev/stdout)
+
+        cardano-cli latest address build \
+          --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") \
+          --stake-verification-key-file <(echo -n "$STAKE_VKEY_FROM_EXT")
+        }
+    fi
+  )
+
+  echo "For environment $ENV, the source address of $SOURCE_ADDR contains the following lovelace only UTxOs:"
+  cardano-cli latest query utxo --address "$SOURCE_ADDR" | jq 'to_entries | map(select(.value.value | length == 1)) | sort_by(.value.value.lovelace) | from_entries'
+  PROMPT
+
+  echo "For environment $ENV, the send to address of $SEND_ADDR contains the following lovelace only UTxOs:"
+  cardano-cli latest query utxo --address "$SEND_ADDR" | jq 'to_entries | map(select(.value.value | length == 1)) | sort_by(.value.value.lovelace) | from_entries'
+  PROMPT
+
+  echo "The provided UTXO has an ID and value of:"
+  SELECTED_UTXO=$(
+    cardano-cli latest query utxo \
+      --address "$SOURCE_ADDR" \
+      --testnet-magic "$TESTNET_MAGIC" \
+    | jq -e -r --arg selectedUtxo "$UTXO" 'to_entries[]
+      |
+        select(.key == $selectedUtxo)
+          | {"txin": .key, "address": .value.address, "amount": .value.value.lovelace}'
+  )
+
+  TXIN=$(jq -r .txin <<< "$SELECTED_UTXO")
+  TXIN_VALUE=$(jq -r .amount <<< "$SELECTED_UTXO")
+  echo "  UTXO: $TXIN"
+  echo "  Value: $TXIN_VALUE"
+  echo
+  echo "Assembling transaction with details of:"
+  echo "  Send to address: $SEND_ADDR"
+  echo "  From address: $SOURCE_ADDR"
+  echo "  Send amount: $TXIN_VALUE lovelace"
+  echo "  Fee amount: 0.2 ADA"
+  echo "  Funding UTxO: $TXIN"
+  echo "  Funding UTxO value: $TXIN_VALUE lovelace"
+  PROMPT
+
+  cardano-cli latest transaction build-raw \
+    --tx-in "$TXIN" \
+    --tx-out "$SEND_ADDR+$((TXIN_VALUE - 200000))" \
+    --fee 200000 \
+    --out-file "$BASENAME.raw"
+
+  # shellcheck disable=2116
+  SIGNING_CMD=$(echo "cardano-cli latest transaction sign \
+    --tx-body-file \"\$BASENAME.raw\" \
+    --signing-key-file <(echo -n \"\$PAYMENT_SKEY\") \
+    ${SIGNING_TX_ARGS[*]} \
+    --testnet-magic \"\$TESTNET_MAGIC\" \
+    --out-file \$BASENAME.signed"
+  )
+  eval "$SIGNING_CMD"
+
+  echo
+  echo "The transaction has been prepared and signed:"
+  cardano-cli debug transaction view --tx-file "$BASENAME.signed"
+  echo
+  echo "If you answer affirmative to the next prompt this transaction will be submitted to the network!"
+  PROMPT
+
+  submit "$BASENAME.signed"
+)
+
+# A handy faucet submission function with mempool monitoring, usable on custom networks.
+# CARDANO_NODE_{NETWORK_ID,SOCKET_PATH}, TESTNET_MAGIC should already be exported.
+# SEND_ADDR, LOVELACE, RICH_ADDR and RICH vars need to be provided.
+faucet() (
+  SEND_ADDR="$1"
+  LOVELACE="$2"
+
+  UTXOS=$(cardano-cli query utxo --address "$RICH_ADDR")
+  UTXO=$(jq -r 'to_entries | max_by(.value.value.lovelace) | { (.key): .value }' <<< "$UTXOS")
+  UTXO_TX=$(jq -r 'keys[0]' <<< "$UTXO")
+
+  cardano-cli latest transaction build \
+    --tx-in "$UTXO_TX" \
+    --tx-out "$SEND_ADDR+$LOVELACE" \
+    --change-address "$RICH_ADDR" \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --out-file faucet.txbody
+
+  cardano-cli latest transaction sign \
+    --tx-body-file faucet.txbody \
+    --signing-key-file "$RICH.skey" \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --out-file faucet.txsigned
+
+  submit faucet.txsigned
 )

--- a/scripts/lib/cli.py
+++ b/scripts/lib/cli.py
@@ -53,7 +53,7 @@ def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_sign
 
     signed_tx = signTx(tx_prefix, utxo_signing_key_str)
 
-    p = subprocess.run([cardanoCliStr(), "latest", "transaction", "txid", "--tx-file", signed_tx], capture_output=True, text=True)
+    p = subprocess.run([cardanoCliStr(), "latest", "transaction", "txid", "--output-text", "--tx-file", signed_tx], capture_output=True, text=True)
     new_txin = p.stdout.rstrip()
     return (f"{new_txin}#0", tx_out_amount, fee)
 
@@ -66,6 +66,7 @@ def estimateFeeTx(txbody, txin_count, txout_count, pparams) -> int:
         "--tx-out-count", str(txout_count),
         "--witness-count", "1",
         "--protocol-params-file", pparams,
+        "--output-text",
         "--tx-body-file", txbody]
 
     p = subprocess.run(cmd, capture_output=True, text=True)

--- a/scripts/recipes/governance.just
+++ b/scripts/recipes/governance.just
@@ -69,6 +69,22 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     exit 1
   fi
 
+  L_JUSTIFY() {
+    DESC="$1"
+    VALUE="$2"
+    COL="$3"
+
+    printf "  %s%*s%s\n" "$DESC" $((COL - ${#DESC})) "" "$VALUE"
+  }
+
+  R_JUSTIFY() {
+    DESC="$1"
+    VALUE="$2"
+    COL="$3"
+
+    printf "  %s%*s%s\n" "$DESC" $((COL - ${#DESC} - ${#VALUE})) "" "$VALUE"
+  }
+
   # Arg setup
   ACTION_UTXO="{{ACTION_ID}}"
   ACTION_IDX="{{ACTION_IDX}}"
@@ -77,8 +93,8 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
 
   # Basic query info
   echo "Current voting status for:"
-  echo "  ACTION_ID: $ACTION_ID"
-  echo "  ACTION_BECH: $ACTION_BECH"
+  L_JUSTIFY "ACTION_ID:" "$ACTION_ID" 35
+  L_JUSTIFY "ACTION_BECH:" "$ACTION_BECH" 35
   echo
 
   CURRENT_EPOCH=$(jq -re .epoch <<< "$TIP")
@@ -90,25 +106,49 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     exit 1
   fi
 
-  # DREP_PWR_DIST is similar to DREP_DIST but only includes active dreps and
-  # those without `drep-alwaysAbstain` and `drep-noConfidence`.
   EPOCH=$(jq -re .epoch <<< "$TIP")
-  DREP_DIST=$(eval "$CARDANO_CLI" latest query drep-stake-distribution --all-dreps 2> /dev/null)
+
+  # The drep-stake-distribution query includes expired dreps and system
+  # alwaysAbstain and alwaysNoConfidence dreps which are funded directly from
+  # stake delegation.
+  DREP_DIST=$(eval "$CARDANO_CLI" latest query drep-stake-distribution --all-dreps 2> /dev/null | jq 'to_entries | map([.key, .value])')
+
+  # DREP_PWR_DIST is similar to DREP_DIST but excludes expired dreps and system dreps (alwaysAbstain and alwaysNoConfidence).
   DREP_PWR_DIST=$(eval "$CARDANO_CLI" latest query drep-state --all-dreps --include-stake \
     | jq -re "[ .[] | select( .[1].expiry >= $EPOCH ) | [\"drep-\(.[0] | keys[0])-\(.[0] | to_entries[].value)\", (.[1].stake // 0)]]" 2> /dev/null)
+
+  # Get a distribution of all expired dreps
+  DREP_EXP_PWR_DIST=$(eval "$CARDANO_CLI" latest query drep-state --all-dreps --include-stake \
+    | jq -re "[ .[] | select( .[1].expiry < $EPOCH ) | [\"drep-\(.[0] | keys[0])-\(.[0] | to_entries[].value)\", (.[1].stake // 0)]]" 2> /dev/null)
+
+  # Calculate active and inactive drep power based on valid or expired dreps
   DREP_PWR_ACTIVE=$(jq -re "[.[][1]] | add // 0" <<< "$DREP_PWR_DIST" 2> /dev/null)
-  DREP_STAKE_TOTAL=$(jq -re '[del(.[] | select(.[0] == "drep-alwaysAbstain" or .[0] == "drep-alwaysNoConfidence")) | .[][1]] | add' <<< "$DREP_DIST" 2> /dev/null)
+  DREP_PWR_INACTIVE=$(jq -re "[.[][1]] | add // 0" <<< "$DREP_EXP_PWR_DIST" 2> /dev/null)
+
+  # All drep stake, including stake held by expired dreps, and stake auto delegated to always abstain or always no-confidence
+  DREP_STAKE_TOTAL=$(jq -re '[.[][1]] | add' <<< "$DREP_DIST" 2> /dev/null)
+
+  # This is always 1 length for drep-alwaysNoConfidence;
   DREP_NOCONF_COUNT=$(jq -re '[.[] | select(.[0] == "drep-alwaysNoConfidence") | .[1]] | length' <<< "$DREP_DIST" 2> /dev/null)
   DREP_NOCONF_TOTAL=$(jq -re '(.[] | select(.[0] == "drep-alwaysNoConfidence") | .[1]) // 0' <<< "$DREP_DIST" 2> /dev/null)
-  echo "Some potentially useful metrics:"
-  echo "  CURRENT_EPOCH: $CURRENT_EPOCH"
-  echo "  DREP_POWER_ACTIVE: $DREP_PWR_ACTIVE"
-  echo "  DREP_STAKE_TOTAL: $DREP_STAKE_TOTAL"
-  echo "  DREP_NOCONF_TOTAL: $DREP_NOCONF_TOTAL"
+
+  DREP_ALWAYS_ABSTAIN_TOTAL=$(jq -re '(.[] | select(.[0] == "drep-alwaysAbstain") | .[1]) // 0' <<< "$DREP_DIST" 2> /dev/null)
+  echo "Some useful metrics:"
+  R_JUSTIFY "CURRENT_EPOCH:" "$CURRENT_EPOCH" 50
+  R_JUSTIFY "DREP_POWER_ACTIVE:" "$DREP_PWR_ACTIVE" 50
+  R_JUSTIFY "DREP_POWER_INACTIVE:" "$DREP_PWR_INACTIVE" 50
+  R_JUSTIFY "DREP_STAKE_TOTAL:" "$DREP_STAKE_TOTAL" 50
+  R_JUSTIFY "DREP_NOCONF_TOTAL:" "$DREP_NOCONF_TOTAL" 50
+  R_JUSTIFY "DREP_ALWAYS_ABSTAIN:" "$DREP_ALWAYS_ABSTAIN_TOTAL" 50
 
   POOL_DIST=$(eval "$CARDANO_CLI" latest query spo-stake-distribution --all-spos 2> /dev/null)
   POOL_STAKE_TOTAL=$(jq -re '[.[][1]] | add // 0' <<< "$POOL_DIST" 2> /dev/null)
-  echo "  POOL_STAKE_TOTAL: $POOL_STAKE_TOTAL"
+  POOL_ABSTAIN_TOTAL=$(jq -re '[(.[] | select(.[2] == "drep-alwaysAbstain")) | .[1]] | add // 0' <<< "$POOL_DIST")
+  POOL_NOCONF_TOTAL=$(jq -re '[(.[] | select(.[2] == "drep-alwaysNoConfidence")) | .[1]] | add // 0' <<< "$POOL_DIST")
+
+  R_JUSTIFY "POOL_STAKE_TOTAL:" "$POOL_STAKE_TOTAL" 50
+  R_JUSTIFY "POOL_ABSTAIN_TOTAL:" "$POOL_ABSTAIN_TOTAL" 50
+  R_JUSTIFY "POOL_NOCONF_TOTAL:" "$POOL_NOCONF_TOTAL" 50
 
   COMMITTEE_DIST=$(eval "$CARDANO_CLI" latest query committee-state \
     | jq -re '
@@ -127,7 +167,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
   COMMITTEE_TOTAL=$(jq -re "length // 0" <<< "$COMMITTEE_DIST" 2> /dev/null)
   COMMITTEE_THRESHOLD=$(jq -re '"\(.committee.threshold)" // 0' <<< "$GOV_STATE" 2> /dev/null)
   COMMITTEE_THRESHOLD_TYPE=$(jq -re "type" <<< "$COMMITTEE_THRESHOLD" 2> /dev/null)
-  echo "  COMMITTEE_TOTAL: $COMMITTEE_TOTAL"
+  R_JUSTIFY "COMMITTEE_TOTAL:" "$COMMITTEE_TOTAL" 50
 
   case "$COMMITTEE_THRESHOLD_TYPE" in
     "object")
@@ -147,7 +187,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
 
   PPARAMS=$(eval "$CARDANO_CLI" latest query protocol-parameters)
   PROT_MAJOR_VER=$(jq -re ".protocolVersion.major // -1" <<< "$PPARAMS" 2> /dev/null)
-  echo "  PROT_MAJOR_VER: $PROT_MAJOR_VER"
+  R_JUSTIFY "PROT_MAJOR_VER:" "$PROT_MAJOR_VER" 50
 
   {
     read -r ACTION_TAG
@@ -188,14 +228,14 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     (.committeeVotes | with_entries(select(.value | contains("No"))) | length),
     (.committeeVotes | with_entries(select(.value | contains("Abstain"))) | length)' <<< "$ACTION")"
 
-    echo "  ACTION_TAG: $ACTION_TAG"
-    echo "  ACTION_ANCHOR_URL: $ACTION_ANCHOR_URL"
-    echo "  ACTION_ANCHOR_HASH: $ACTION_ANCHOR_HASH"
-    echo "  ACTION_PROPOSED_IN_EPOCH: $ACTION_PROPOSED_IN_EPOCH"
-    echo "  ACTION_EXPIRES_AFTER_EPOCH: $ACTION_EXPIRES_AFTER_EPOCH"
-    echo "  ACTION_DEPOSIT_RETURN_KEY_TYPE: $ACTION_DEPOSIT_RETURN_KEY_TYPE"
-    echo "  ACTION_DEPOSIT_RETURN_HASH: $ACTION_DEPOSIT_RETURN_HASH"
-    echo "  ACTION_DEPOSIT_RETURN_NETWORK: $ACTION_DEPOSIT_RETURN_NETWORK"
+    L_JUSTIFY "ACTION_TAG:" "$ACTION_TAG" 35
+    L_JUSTIFY "ACTION_ANCHOR_URL:" "$ACTION_ANCHOR_URL" 35
+    L_JUSTIFY "ACTION_ANCHOR_HASH:" "$ACTION_ANCHOR_HASH" 35
+    L_JUSTIFY "ACTION_PROPOSED_IN_EPOCH:" "$ACTION_PROPOSED_IN_EPOCH" 35
+    L_JUSTIFY "ACTION_EXPIRES_AFTER_EPOCH:" "$ACTION_EXPIRES_AFTER_EPOCH" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_KEY_TYPE:" "$ACTION_DEPOSIT_RETURN_KEY_TYPE" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_HASH:" "$ACTION_DEPOSIT_RETURN_HASH" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_NETWORK:" "$ACTION_DEPOSIT_RETURN_NETWORK" 35
 
     # Generate lists with the DRep hashes that are voted yes, no or abstain.
     # Add a 'drep-' in front of each entry to mach up the syntax in the `drep-stake-distribution` json.
@@ -222,6 +262,11 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     # Calculate the acceptance percentage for the drep group
     if [ "$ACTION_TAG" != "NoConfidence" ]; then
       # Do a normal percentage calculation if not a `NoConfidence` action
+      # DREP_PWR_ACTIVE is drep stake for dreps who have not expired and it does not include alwaysNoConfidence or alwaysAbstain delegation
+      # DREP_NOCONF_TOTAL is only from direct stake key delegation and should be counted in the denominator
+      # DREP_STAKE_ABSTAIN is summed stake from explicit drep abstain votes
+      # which need to be removed from threshold denominator; the system
+      # alwaysAbstrain drep has already been excluded by using DREP_PWR_ACTIVE.
       DREP_PCT=$(bc <<< "scale=2; 100.00 * $DREP_STAKE_YES / ($DREP_PWR_ACTIVE + $DREP_NOCONF_TOTAL - $DREP_STAKE_ABSTAIN)" 2> /dev/null)
     else
       # Or, if a `NoConfidence` action, the always no confidence counts as yes
@@ -564,7 +609,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
             read -r DENOMINATOR
           } <<< "$(jq -re '.numerator // "-", .denominator // "-"' <<< "$COMMITTEE_THRESHOLD")"
           COMMITTEE_THRESHOLD=$(bc <<< "scale=0; ($NUMERATOR * 100 / $DENOMINATOR) / 1")
-          echo -e "Approval of a governance measure requires $NUMERATOR out of $DENOMINATOR ($COMMITEE_THRESHOLD%) of the votes of committee members.$OFF\n"
+          echo -e "Approval of a governance measure requires $NUMERATOR out of $DENOMINATOR ($COMMITTEE_THRESHOLD%) of the votes of committee members.$OFF\n"
           ;;
 
         "number")
@@ -575,16 +620,22 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
 
       ADD_HASHES_RENDER=$(jq -re "
         .[2] // {}
-          | to_entries[]
-          | \"Adding $GREEN\(.key)-\(.value)\"
-          | split(\"-\") | \"\(.[0])$OFF ► $BLUE\(.[1])$OFF (max term epoch \(.[2]))\"
+          | to_entries as \$entries
+          | if (\$entries | length) > 0
+            then []
+              | \"Adding $GREEN\(.key)-\(.value)\"
+              | split(\"-\")
+              | \"\(.[0])$OFF ► $BLUE\(.[1])$OFF (max term epoch \(.[2]))\"
+            else \"No additions\"
+            end
       " <<< "$ACTION_CONTENTS" 2> /dev/null)
 
       REM_HASHES_RENDER=$(jq -re "
         .[1][] // []
           | to_entries as \$entries
           | if (\$entries | length > 0)
-            then \"Remove $GREEN\(\$entries | .key)$OFF ◄ $RED\(\$entries | .value)$OFF\"
+            then \$entries[]
+              | \"Remove $GREEN\(.key)$OFF ◄ $RED\(.value)$OFF\"
             else \"No removals\"
             end
       " <<< "$ACTION_CONTENTS" 2> /dev/null)
@@ -941,7 +992,7 @@ vote-with-pool ENV POOL ACTION_ID ACTION_IDX VOTE:
   EXISTS="true"
 
   while [ "$EXISTS" = "true" ]; do
-    EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
+    EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists || true)
     if [ "$EXISTS" = "true" ]; then
       echo "Vote transaction still exists in the mempool, sleeping 5s: $TXID"
     else

--- a/scripts/restore-delegation-accounts.py
+++ b/scripts/restore-delegation-accounts.py
@@ -261,7 +261,7 @@ def signTx(tx_body, utxo_signing_key_str, stake_signing_key, out_file):
     if p.returncode != 0:
         print(p.stderr)
         raise Exception("Unknown error signing transaction")
-    cli_args = ["cardano-cli", "latest", "transaction", "txid", "--tx-file", out_file]
+    cli_args = ["cardano-cli", "latest", "transaction", "txid", "--output-text", "--tx-file", out_file]
     p = subprocess.run(cli_args, input=None, capture_output=True, text=True)
     if p.returncode != 0:
         print(p.stderr)

--- a/secrets/tf/cluster.tfvars
+++ b/secrets/tf/cluster.tfvars
@@ -1,0 +1,15 @@
+{
+	"data": "ENC[AES256_GCM,data:wmj5YofXugDLBDZehbgrZRzE7BdP8to2+w==,iv:EhL/TK7N7G6ayg8fpx3PUUWg0sQXftHZiPTs8kr3zZY=,tag:oBzN3neWFp/z11KWaXcBqg==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"recipient": "age1a38xzsfp4nq3vg60xjhjcxswxd0n5l4sdav0uu60tr6g32vww3ks8y9d4m",
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0ampEYWJYZWVxTURoaGlR\nMmtPd1RKMlJRMHovb1k5a09VVjdkZHkyNUFFClI5SWdPK0JmQm1IQ3RNbFJ2aFdD\nV3RqY3pTNi9iTVRNSEhKWDJyVS96QjgKLS0tIFhNRHorNXBQZjA3b3NBbE5qSzBu\nQzdmMmp4ajg1cEtndWNjbUdsTHh1VDAKhA39PjyzJreS2N6gxC2zc50ZdYnHM0xU\n6djbwMFn+8e0baqEzPWwOBNW8KZe13xyRnxliplO37wWGzylqc5KaA==\n-----END AGE ENCRYPTED FILE-----\n"
+			}
+		],
+		"lastmodified": "2025-11-08T01:45:15Z",
+		"mac": "ENC[AES256_GCM,data:2mHMSqhzQklVedzLPBlfPtNvzbSGMz6g26FSeLYIdVIchgS9lYKQidJ15YyDTih27zpDwGk8l7kP+PkTpIMXDfM+cRPYcUztlPBPwTWz5RxjqlUkT2WKpW94lBSgFetHNp2xsBgpVG1F1XK6IYw/wkqjMPicBMgqd7wvnyjIKjE=,iv:Up5jzNyYjFzltmm0nsi9gvWBZghTlInlSJFQsw5fWzE=,tag:Fzx7EifXlO0DNmr6Ba4Lyw==,type:str]",
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.10.2"
+	}
+}


### PR DESCRIPTION
* Parts was bumped from `v2025-06-24` to post-`v2025-08-14` at `next-2025-08-14`
* Existing machines are still left at a default of `legacyTracing` for now
* New dashboards with updates for new tracing have not been committed yet, as there was some prior dashboard customization.  The updated dashboards with the latest cardano-parts release can be pulled in when needed.
* Updates for breaking changes were applied.
* Adds new resource tags to both cloudFormation and tofu resources: `owner`, `project`, `costCenter`
* Updates the pre-existing `organization` and `environment` tags
* Treats costCenter tag as secret and adds a corresponding secrets file
* Updates justfile, cloudFormation state template and tofu cluster definition files to accommodate